### PR TITLE
fix:can build

### DIFF
--- a/GD32F5xx/SConscript
+++ b/GD32F5xx/SConscript
@@ -30,6 +30,9 @@ if GetDepend(['RT_USING_PWM']):
 if GetDepend(['RT_USING_CAN']):
     src += ['GD32F5xx_standard_peripheral/Source/gd32f5xx_can.c']
 
+if GetDepend(['BSP_USING_GD_DBG']):
+    src += ['GD32F5xx_standard_peripheral/Source/gd32f5xx_dbg.c']
+
 if GetDepend(['BSP_USING_ETH']):
     src += ['GD32F5xx_standard_peripheral/Source/gd32f5xx_enet.c']
 


### PR DESCRIPTION
<img width="1189" height="1341" alt="PixPin_2025-09-25_12-10-05" src="https://github.com/user-attachments/assets/88652a16-0059-48c5-b3c9-dabe82ee4f50" />
cand的库函数需要依赖dbg