### PR TITLE
Add GD32F4xx timer source for PWM builds

### DIFF
--- a/GD32F4xx/SConscript
+++ b/GD32F4xx/SConscript
@@ -36,6 +36,9 @@ if GetDepend(['RT_USING_ADC']):
 if GetDepend(['RT_USING_DAC']):
     src += ['GD32F4xx_standard_peripheral/Source/gd32f4xx_dac.c']
 
+if GetDepend(['RT_USING_PWM']) or GetDepend(['RT_USING_HWTIMER']):
+    src += ['GD32F4xx_standard_peripheral/Source/gd32f4xx_timer.c']
+
 if GetDepend(['RT_USING_RTC']):
     src += ['GD32F4xx_standard_peripheral/Source/gd32f4xx_rtc.c']
     src += ['GD32F4xx_standard_peripheral/Source/gd32f4xx_pmu.c']


### PR DESCRIPTION
## What changed

Add `GD32F4xx_standard_peripheral/Source/gd32f4xx_timer.c` when `RT_USING_PWM` or `RT_USING_HWTIMER` is enabled.

## Why

`drv_pwm.c` directly calls GD32 timer standard peripheral APIs such as `timer_deinit`, `timer_channel_output_config`, and `timer_enable`. When RT-Thread PR #11547 added CI attach coverage for `gd32405rg` PWM0, the BSP linked `drv_pwm.o` but the GD32F4xx package did not link `gd32f4xx_timer.c`, causing undefined `timer_*` references.

## Validation

- `git diff --check`
- `python -m py_compile GD32F4xx/SConscript`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hardware timer support when PWM or high-resolution timer features are enabled.
  * Related timer functionality is now included automatically in builds that use those capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->